### PR TITLE
stop trying to use removed global SELF_USER_AGENT

### DIFF
--- a/init.php
+++ b/init.php
@@ -174,7 +174,7 @@ class Options_Per_Feed extends Plugin
 		if (!empty($options["user_agent"])) {
 			curl_setopt($ch, CURLOPT_USERAGENT, $options["user_agent"]);
 		} else {
-			curl_setopt($ch, CURLOPT_USERAGENT, SELF_USER_AGENT);
+			curl_setopt($ch, CURLOPT_USERAGENT, Config::get_user_agent());
 		}
 
 		if (empty($options["ssl_verify"])) {


### PR DESCRIPTION
Resolves "undefined constant" error under PHP 8, a la https://git.tt-rss.org/fox/ttrss-af-unburn.git/commit/?id=e0050a12f60843a940a5c3b14f80fc8d39dfb0d2